### PR TITLE
Update regex to match preid in version number

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,8 +9,7 @@ module.exports = function(options, cb) {
 
   var regex = opts.regex || new RegExp(
     '([\'|\"]?' + opts.key + '[\'|\"]?[ ]*:[ ]*[\'|\"]?)(\\d+\\.\\d+\\.\\d+(-' +
-    opts.preid +
-    '\\.\\d+)?(-\\d+)?)[\\d||A-a|.|-]*([\'|\"]?)', 'i');
+    '(?:[0-9A-Za-z-]+)\\.\\d+)?(-\\d+)?)[\\d||A-a|.|-]*([\'|\"]?)', 'i');
 
   if (opts.global) {
     regex = new RegExp(regex.source, 'gi');
@@ -35,4 +34,3 @@ module.exports = function(options, cb) {
 
   return cb(null, opts);
 };
-


### PR DESCRIPTION
Fixes #3 

I replaced `opts.preid` with a non-capturing group that will match a pre-release identifier if present in the version number. See http://semver.org/#spec-item-9. This allows you to bump the version from `1.0.0-rc.0` to `1.0.0-rc.1` without specifying the preid on the command line.