### PR TITLE
Fix key with dashes being treated as a range - closes #11

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ module.exports = function(options, cb) {
 
   var regex = opts.regex || new RegExp(
     '([<|\'|\"]?' + opts.key + '[>|\'|\"]?[ ]*[:=]?[ ]*[\'|\"]?[a-z]?)(\\d+\\.\\d+\\.\\d+)' +
-    '(-[0-9A-Za-z\.-]+)?([\'|\"|<' + opts.key + '>]?)', + opts.case ? '' : 'i');
+    '(-[0-9A-Za-z\.-]+)?([\'|\"|<]?)', + opts.case ? '' : 'i');
 
   if (opts.global) {
     regex = new RegExp(regex.source, 'gi');

--- a/test/index.js
+++ b/test/index.js
@@ -68,7 +68,18 @@ lab.experiment(PROJECT_NAME, function() {
       code.expect(out.str).to.equal('{"appversion":"0.1.1"}');
       done();
     });
+  });
 
+  lab.test('set key with dash', function(done) {
+    var opts = {
+      str: JSON.stringify({'latest-release': '0.1.1'}),
+      key: 'latest-release'
+    };
+    project(opts, function(err, out) {
+      code.expect(err).to.equal(null);
+      code.expect(out.str).to.equal('{"latest-release":"0.1.2"}');
+      done();
+    });
   });
 
   lab.test('set preid', function(done) {
@@ -83,7 +94,6 @@ lab.experiment(PROJECT_NAME, function() {
       code.expect(out.str).to.equal('{"version":"0.1.1-thing.0"}');
       done();
     });
-
   });
 
   lab.test('set preid', function(done) {


### PR DESCRIPTION
I removed the `key` when looking for the closing tag of a XML element. It'd would be sufficient to look for the `<` character. By doing so, the key is no longer treated as a range when it contains a `-`(dash).