### PR TITLE
added keepmetadata option

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,13 @@ Set the version selector regex
 
     Type: `RegEx`
 
+### options.keepmetadata
+Keep the metadata of the old version after bumping
+(exception: you are using options.version)
+
+    Type: `Boolean`
+    Default: `false`
+
 Example:
 
 ```js

--- a/index.js
+++ b/index.js
@@ -63,11 +63,11 @@ module.exports = function(options, cb) {
     opts.prev = parsed;
     opts.new = version;
     
-    if (opts.keepmetadata && !opts.version) {
-      suffix = suffix + metadata;
+    if (!opts.keepmetadata || !!opts.version) {
+      metadata = '';
     }
     
-    return prefix + version + (suffix || '');
+    return prefix + version + (metadata || '') + (suffix || '');
   });
 
   if (!parsedOut) {

--- a/index.js
+++ b/index.js
@@ -14,7 +14,8 @@ module.exports = function(options, cb) {
     key: 'version',
     type: 'patch',
     case: false,
-    keys: null
+    keys: null,
+    keepmetadata: false
   }
 
   var opts = extend(defaultOpts, options);
@@ -61,6 +62,11 @@ module.exports = function(options, cb) {
     var version = opts.version || semver.inc(parsed, opts.type, opts.preid);
     opts.prev = parsed;
     opts.new = version;
+    
+    if (opts.keepmetadata && !opts.version) {
+      suffix = suffix + metadata;
+    }
+    
     return prefix + version + (suffix || '');
   });
 

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "lab": "^10.2.0"
   },
   "scripts": {
-    "test": "lab test/*.js -v"
+    "test": "lab test/index.js -v"
   },
   "engines": {
     "node": ">= 0.12.0"

--- a/test/index.js
+++ b/test/index.js
@@ -364,4 +364,113 @@ lab.experiment(PROJECT_NAME, function() {
       done();
     });
   });
+
+
+  lab.test('patch with keepmetadata false', function(done) {
+    var opts = {
+      type: 'patch',
+      str: JSON.stringify({version: '0.1.0+meta.1'})
+    };
+    project(opts, function(err, out) {
+      code.expect(err).to.equal(null);
+      code.expect(out.str).to.equal('{"version":"0.1.1"}');
+      done();
+    });
+  });
+
+  lab.test('minor with keepmetadata false', function(done) {
+    var opts = {
+      type: 'minor',
+      str: JSON.stringify({version: '0.1.0+meta.1'})
+    };
+    project(opts, function(err, out) {
+      code.expect(err).to.equal(null);
+      code.expect(out.str).to.equal('{"version":"0.2.0"}');
+      done();
+    });
+  });
+
+  lab.test('major with keepmetadata false', function(done) {
+    var opts = {
+      type: 'major',
+      str: JSON.stringify({version: '0.1.0+meta.1'})
+    };
+    project(opts, function(err, out) {
+      code.expect(err).to.equal(null);
+      code.expect(out.str).to.equal('{"version":"1.0.0"}');
+      done();
+    });
+  });
+
+  lab.test('update existing prerelease without preid with keepmetadata false', function(done) {
+    var opts = {
+      str: JSON.stringify({version: '0.1.0-rc.0+meta.1'}),
+      type: 'prerelease'
+    };
+
+    project(opts, function(err, out) {
+      code.expect(err).to.equal(null);
+      code.expect(out.str).to.equal('{"version":"0.1.0-rc.1"}');
+      done();
+    });
+
+  });
+
+  lab.test('patch with keepmetadata true', function(done) {
+    var opts = {
+      type: 'patch',
+      str: JSON.stringify({version: '0.1.0+meta.1'}),
+      keepmetadata: true
+    };
+
+    project(opts, function(err, out) {
+      code.expect(err).to.equal(null);
+      code.expect(out.str).to.equal('{"version":"0.1.1+meta.1"}');
+      done();
+    });
+  });
+
+  lab.test('minor with keepmetadata true', function(done) {
+    var opts = {
+      type: 'minor',
+      str: JSON.stringify({version: '0.1.0+meta.1'}),
+      keepmetadata: true
+    };
+
+    project(opts, function(err, out) {
+      code.expect(err).to.equal(null);
+      code.expect(out.str).to.equal('{"version":"0.2.0+meta.1"}');
+      done();
+    });
+  });
+
+  lab.test('major with keepmetadata true', function(done) {
+    var opts = {
+      type: 'major',
+      str: JSON.stringify({version: '0.1.0+meta.1'}),
+      keepmetadata: true
+    };
+
+    project(opts, function(err, out) {
+      code.expect(err).to.equal(null);
+      code.expect(out.str).to.equal('{"version":"1.0.0+meta.1"}');
+      done();
+    });
+  });
+
+  lab.test('update existing prerelease without preid with keepmetadata true', function(done) {
+    var opts = {
+      str: JSON.stringify({version: '0.1.0-rc.0+meta.1'}),
+      type: 'prerelease',
+      keepmetadata: true
+    };
+
+    project(opts, function(err, out) {
+      code.expect(err).to.equal(null);
+      code.expect(out.str).to.equal('{"version":"0.1.0-rc.1+meta.1"}');
+      done();
+    });
+
+  });
+
 });


### PR DESCRIPTION
As in #20 described, the current version removes the metadata on the version string.
So I added an option to keep the metadata after bump.