### PR TITLE
Return correct update type when setting version

### DIFF
--- a/index.js
+++ b/index.js
@@ -62,6 +62,10 @@ module.exports = function(options, cb) {
     var version = opts.version || semver.inc(parsed, opts.type, opts.preid);
     opts.prev = parsed;
     opts.new = version;
+
+    if (opts.version) {
+      opts.type = semver.diff(opts.prev, opts.new);
+    }
     
     if (!opts.keepmetadata || !!opts.version) {
       metadata = '';

--- a/test/index.js
+++ b/test/index.js
@@ -235,6 +235,17 @@ lab.experiment(PROJECT_NAME, function() {
     });
   });
 
+  lab.test('return update type of set version', function(done) {
+    var opts = {
+      str: JSON.stringify({version: '0.0.1'}),
+      version: '1.0.0'
+    };
+    project(opts, function(err, out) {
+      code.expect(out.type).to.equal('major');
+      done();
+    });
+  });
+
   lab.test('return prev version', function(done) {
     var opts = {
       str: JSON.stringify({version: '1.2.0'})


### PR DESCRIPTION
Calculates and overrides the default update type when setting a version explicitly. This fixes stevelacy/gulp-bump#59.